### PR TITLE
Sanity check Graph Fix

### DIFF
--- a/Multivariate GARCH.ipynb
+++ b/Multivariate GARCH.ipynb
@@ -724,8 +724,8 @@
     "\n",
     "\n",
     "axs[1].set_title(\"Sanity check: Model predicted VS. rolling correlation\",size=20)\n",
-    "axs[1].plot(returns.index[30:],gdaxi_sp500.values[30:],c=\"green\", label=\"60 day rolling correlation\")\n",
-    "axs[1].plot(returns.index[30:],corr12[30:],c=\"red\", label=\"MGARCH in-sample conditional correlation\")\n",
+    "axs[1].plot(returns.index[30:],gdaxi_sp500_rollcorr.values[30:],c=\"green\", label=\"60 day rolling correlation\")\n",
+    "axs[1].plot(returns.index[30:],conditional_correlations[30:],c=\"red\", label=\"MGARCH in-sample conditional correlation\")\n",
     "axs[1].grid(alpha=0.5)\n",
     "axs[1].legend(prop = {\"size\":13})\n",
     "axs[1].margins(x=0)"


### PR DESCRIPTION
Just a fix for the last Notebook cell where the variables were not inputted correctly.

The graph would now use gdaxi_sp500_rollcorr and conditional_correlations. It is consistent with the values in the output cells that you originally uploaded.